### PR TITLE
Hyperlink UC Davis in footer

### DIFF
--- a/src/layouts/components/Footer.vue
+++ b/src/layouts/components/Footer.vue
@@ -15,7 +15,15 @@
     </span>
     
     <span class="footer-text">
-      Copyright © {{ new Date().getFullYear() }} The Regents of the University of California, Davis campus. All rights reserved. Used with permission.
+      Copyright © {{ new Date().getFullYear() }} The Regents of the
+      <a
+        href="https://www.ucdavis.edu/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="footer-link"
+        >University of California, Davis</a
+      >
+      campus. All rights reserved. Used with permission.
     </span>
 
     <span class="footer-text">


### PR DESCRIPTION
## Summary
- hyperlink "University of California, Davis" text in footer to the UC Davis website

## Testing
- `npm run lint` *(fails: cannot find `.eslintrc.cjs`)*

------
https://chatgpt.com/codex/tasks/task_e_688188afd96c832abf6d43c6cef01911