### PR TITLE
Add login and registration pages

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const userId = ref('')
+const password = ref('')
+const router = useRouter()
+
+const submit = () => {
+  // Placeholder authentication logic
+  router.push('/dashboard')
+}
+</script>
+
+<template>
+  <VContainer class="d-flex align-center justify-center" style="height: 100vh;">
+    <VCard class="pa-8" max-width="400">
+      <VCardTitle class="text-h5 text-center mb-6">Login</VCardTitle>
+      <VForm @submit.prevent="submit">
+        <VTextField v-model="userId" label="User ID" required class="mb-4" />
+        <VTextField v-model="password" label="Password" type="password" required class="mb-4" />
+        <VBtn type="submit" block class="mb-4">Login</VBtn>
+      </VForm>
+      <div class="text-center">
+        <RouterLink to="/register">Need an account? Register</RouterLink>
+      </div>
+    </VCard>
+  </VContainer>
+</template>

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const fullName = ref('')
+const email = ref('')
+const affiliation = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+const referral = ref('')
+const router = useRouter()
+
+const submit = () => {
+  // Placeholder registration logic
+  router.push('/')
+}
+</script>
+
+<template>
+  <VContainer class="d-flex align-center justify-center" style="height: 100vh;">
+    <VCard class="pa-8" max-width="500">
+      <VCardTitle class="text-h5 text-center mb-6">Register</VCardTitle>
+      <VForm @submit.prevent="submit">
+        <VTextField v-model="fullName" label="Full Name" required class="mb-4" />
+        <VTextField v-model="email" label="Email" type="email" required class="mb-4" />
+        <VTextField v-model="affiliation" label="Affiliation" required class="mb-4" />
+        <VTextField v-model="password" label="Password" type="password" required class="mb-4" />
+        <VTextField v-model="confirmPassword" label="Confirm Password" type="password" required class="mb-4" />
+        <VTextField v-model="referral" label="How did you hear about this app?" class="mb-4" />
+        <VBtn type="submit" block class="mb-4">Register</VBtn>
+      </VForm>
+      <div class="text-center">
+        <RouterLink to="/">Already have an account? Login</RouterLink>
+      </div>
+    </VCard>
+  </VContainer>
+</template>

--- a/src/plugins/router/routes.js
+++ b/src/plugins/router/routes.js
@@ -1,12 +1,28 @@
 export const routes = [
   {
     path: '/',
-    component: () => import('@/layouts/default.vue'), // This points to your layout
+    component: () => import('@/layouts/blank.vue'),
     children: [
       {
-        path: '', // The empty path makes this the default child route
+        path: '',
+        name: 'Login',
+        component: () => import('@/pages/login.vue'),
+      },
+      {
+        path: 'register',
+        name: 'Register',
+        component: () => import('@/pages/register.vue'),
+      },
+    ],
+  },
+  {
+    path: '/dashboard',
+    component: () => import('@/layouts/default.vue'),
+    children: [
+      {
+        path: '',
         name: 'Dashboard',
-        component: () => import('@/pages/dashboard.vue'), // This points to your Dashboard component
+        component: () => import('@/pages/dashboard.vue'),
       },
     ],
   },


### PR DESCRIPTION
## Summary
- add login and register pages with sleek Vuetify forms
- update routing so login is the landing page and register/dashboard routes are available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find module '.eslintrc.cjs')*


------
https://chatgpt.com/codex/tasks/task_e_68b0c2e4c2b4832abf1ee2be43b9a042