### PR TITLE
Connect auth pages to backend endpoints

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,14 +1,62 @@
 <script setup>
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { onMounted, ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 
-const userId = ref('')
+const email = ref('')
 const password = ref('')
+const errorMessage = ref('')
+const successMessage = ref('')
 const router = useRouter()
+const route = useRoute()
 
-const submit = () => {
-  // Placeholder authentication logic
-  router.push('/dashboard')
+onMounted(() => {
+  const msg = typeof route.query.message === 'string' ? route.query.message : ''
+  if (msg)
+    successMessage.value = msg
+
+  // Clear the query so the message doesn't persist on navigation
+  if (Object.keys(route.query).length)
+    router.replace({ query: {} })
+})
+
+const submit = async () => {
+  errorMessage.value = ''
+  try {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: email.value,
+        password: password.value,
+      }),
+    })
+
+    const data = await res.json().catch(() => ({}))
+
+    if (!res.ok) {
+      let msg = data.message
+      if (!msg) {
+        if (res.status === 400)
+          msg = 'Missing email or password.'
+        else if (res.status === 401)
+          msg = 'Invalid email or password.'
+        else
+          msg = `Server returned ${res.status} ${res.statusText}`
+      }
+      throw new Error(msg)
+    }
+
+    router.push('/dashboard')
+  }
+  catch (err) {
+    const message =
+      err instanceof TypeError
+        ? `Network error: ${err.message}`
+        : err.message || 'Login failed.'
+    errorMessage.value = `Login failed: ${message}`
+  }
 }
 
 const socialLogin = provider => {
@@ -33,8 +81,22 @@ const forgotPassword = () => {
       <VCardSubtitle class="text-center mb-8">Sign in to continue to OSSPREY</VCardSubtitle>
 
       <VForm @submit.prevent="submit">
-        <VTextField v-model="userId" label="User ID" required class="mb-4" />
+        <VTextField v-model="email" label="Email" type="email" required class="mb-4" />
         <VTextField v-model="password" label="Password" type="password" required class="mb-4" />
+        <VAlert
+          v-if="successMessage"
+          type="success"
+          density="compact"
+          class="mb-4"
+          :text="successMessage"
+        />
+        <VAlert
+          v-if="errorMessage"
+          type="error"
+          density="compact"
+          class="mb-4"
+          :text="errorMessage"
+        />
         <VBtn type="submit" block size="large" class="mb-4 py-4">Login</VBtn>
       </VForm>
 

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -8,11 +8,54 @@ const affiliation = ref('')
 const password = ref('')
 const confirmPassword = ref('')
 const referral = ref('')
+const errorMessage = ref('')
 const router = useRouter()
 
-const submit = () => {
-  // Placeholder registration logic
-  router.push('/')
+const submit = async () => {
+  errorMessage.value = ''
+
+  if (password.value !== confirmPassword.value) {
+    errorMessage.value = 'Passwords do not match.'
+    return
+  }
+
+  try {
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        full_name: fullName.value,
+        email: email.value,
+        affiliation: affiliation.value,
+        password: password.value,
+        referral: referral.value,
+      }),
+    })
+
+    const data = await res.json().catch(() => ({}))
+
+    if (!res.ok) {
+      let msg = data.message
+      if (!msg) {
+        if (res.status === 400)
+          msg = 'Invalid registration data.'
+        else
+          msg = `Server returned ${res.status} ${res.statusText}`
+      }
+      throw new Error(msg)
+    }
+
+    router.push({ path: '/', query: { message: data.message || 'User registered successfully. Please log in.' } })
+  }
+  catch (err) {
+    const message =
+      err instanceof TypeError
+        ? `Network error: ${err.message}`
+        : err.message || 'Registration failed.'
+    errorMessage.value = `Registration failed: ${message}`
+  }
 }
 </script>
 
@@ -33,7 +76,14 @@ const submit = () => {
         <VTextField v-model="affiliation" label="Affiliation" required class="mb-4" />
         <VTextField v-model="password" label="Password" type="password" required class="mb-4" />
         <VTextField v-model="confirmPassword" label="Confirm Password" type="password" required class="mb-4" />
-        <VTextField v-model="referral" label="How did you hear about this app?" class="mb-4" />
+        <VTextField v-model="referral" label="How did you hear about this app?" required class="mb-4" />
+        <VAlert
+          v-if="errorMessage"
+          type="error"
+          density="compact"
+          class="mb-4"
+          :text="errorMessage"
+        />
         <VBtn type="submit" block size="large" class="mb-4 py-4">Register</VBtn>
       </VForm>
       <VBtn block variant="outlined" size="large" class="mb-4 py-4" to="/">


### PR DESCRIPTION
## Summary
- Display server-sent registration success messages on the login page
- Improve login error handling for missing or invalid credentials
- Require referral on registration and forward backend confirmation to login

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot read config file: .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68b54104c904832ab270a58f80000084