### PR TITLE
feat: enforce registration validation

### DIFF
--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -18,6 +18,18 @@ const submit = async () => {
   errorMessage.value = ''
   successMessage.value = ''
 
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!emailPattern.test(email.value)) {
+    errorMessage.value = 'Please enter a valid email address.'
+    return
+  }
+
+  const passwordPattern = /^(?=.*[A-Z])(?=.*\d).{8,}$/
+  if (!passwordPattern.test(password.value)) {
+    errorMessage.value = 'Password must be at least 8 characters long and include at least one number and one uppercase letter.'
+    return
+  }
+
   if (password.value !== confirmPassword.value) {
     errorMessage.value = 'Passwords do not match.'
     return


### PR DESCRIPTION
## Summary
- validate email format on registration
- enforce strong password requirements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module '.eslintrc.cjs')*


------
https://chatgpt.com/codex/tasks/task_e_68b6ad81f204832aa4a9e2975d641caf