### PR TITLE
feat: improve registration password guidance

### DIFF
--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 const fullName = ref('')
@@ -8,11 +8,29 @@ const affiliation = ref('')
 const password = ref('')
 const confirmPassword = ref('')
 const referral = ref('')
+const referralOptions = [
+  'Search engine',
+  'Social media',
+  'Friend or colleague',
+  'Online advertisement',
+  'Conference or event',
+  'Blog or article',
+  'Other',
+]
 const errorMessage = ref('')
 const successMessage = ref('')
 const router = useRouter()
 
 const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+
+const passwordLengthValid = computed(() => password.value.length >= 8)
+const passwordHasLower = computed(() => /[a-z]/.test(password.value))
+const passwordHasUpper = computed(() => /[A-Z]/.test(password.value))
+const passwordHasNumber = computed(() => /\d/.test(password.value))
+const passwordHasSpecial = computed(() => /[^A-Za-z0-9]/.test(password.value))
+const passwordCategoriesValid = computed(() =>
+  [passwordHasLower.value, passwordHasUpper.value, passwordHasNumber.value, passwordHasSpecial.value].filter(Boolean).length >= 3,
+)
 
 const submit = async () => {
   errorMessage.value = ''
@@ -24,9 +42,8 @@ const submit = async () => {
     return
   }
 
-  const passwordPattern = /^(?=.*[A-Z])(?=.*\d).{8,}$/
-  if (!passwordPattern.test(password.value)) {
-    errorMessage.value = 'Password must be at least 8 characters long and include at least one number and one uppercase letter.'
+  if (!(passwordLengthValid.value && passwordCategoriesValid.value)) {
+    errorMessage.value = 'Password must be at least 8 characters long and include at least three of the following: lower case letters, upper case letters, numbers, and special characters.'
     return
   }
 
@@ -94,12 +111,53 @@ const submit = async () => {
       <VCardTitle class="text-h4 text-center mb-2">Create Account</VCardTitle>
       <VCardSubtitle class="text-center mb-8">Join the OSSPREY community today</VCardSubtitle>
       <VForm @submit.prevent="submit">
-        <VTextField v-model="fullName" label="Full Name" required class="mb-4" />
-        <VTextField v-model="email" label="Email" type="email" required class="mb-4" />
-        <VTextField v-model="affiliation" label="Affiliation" required class="mb-4" />
-        <VTextField v-model="password" label="Password" type="password" required class="mb-4" />
-        <VTextField v-model="confirmPassword" label="Confirm Password" type="password" required class="mb-4" />
-        <VTextField v-model="referral" label="How did you hear about this app?" class="mb-4" />
+        <VTextField v-model="fullName" required class="mb-4">
+          <template #label>Full Name <span class="text-error">*</span></template>
+        </VTextField>
+        <VTextField v-model="email" type="email" required class="mb-4">
+          <template #label>Email <span class="text-error">*</span></template>
+        </VTextField>
+        <VTextField v-model="affiliation" required class="mb-4">
+          <template #label>Affiliation <span class="text-error">*</span></template>
+        </VTextField>
+        <VTextField v-model="password" type="password" required class="mb-4">
+          <template #label>Password <span class="text-error">*</span></template>
+        </VTextField>
+        <VTextField v-model="confirmPassword" type="password" required class="mb-4">
+          <template #label>Confirm Password <span class="text-error">*</span></template>
+        </VTextField>
+        <VSelect v-model="referral" :items="referralOptions" label="How did you hear about this app?" class="mb-4" />
+        <div class="mb-4">
+          <p>Your password must contain:</p>
+          <ul class="pl-4">
+            <li>
+              <VIcon icon="mdi-check" :color="passwordLengthValid ? 'success' : 'error'" class="mr-1" />
+              <span :class="passwordLengthValid ? 'text-success' : 'text-error'">At least 8 characters</span>
+            </li>
+            <li>
+              <VIcon icon="mdi-check" :color="passwordCategoriesValid ? 'success' : 'error'" class="mr-1" />
+              <span :class="passwordCategoriesValid ? 'text-success' : 'text-error'">At least 3 of the following:</span>
+              <ul class="pl-4">
+                <li>
+                  <VIcon icon="mdi-check" :color="passwordHasLower ? 'success' : 'error'" class="mr-1" />
+                  <span :class="passwordHasLower ? 'text-success' : 'text-error'">Lower case letters (a-z)</span>
+                </li>
+                <li>
+                  <VIcon icon="mdi-check" :color="passwordHasUpper ? 'success' : 'error'" class="mr-1" />
+                  <span :class="passwordHasUpper ? 'text-success' : 'text-error'">Upper case letters (A-Z)</span>
+                </li>
+                <li>
+                  <VIcon icon="mdi-check" :color="passwordHasNumber ? 'success' : 'error'" class="mr-1" />
+                  <span :class="passwordHasNumber ? 'text-success' : 'text-error'">Numbers (0-9)</span>
+                </li>
+                <li>
+                  <VIcon icon="mdi-check" :color="passwordHasSpecial ? 'success' : 'error'" class="mr-1" />
+                  <span :class="passwordHasSpecial ? 'text-success' : 'text-error'">Special characters (e.g. !@#$%^&*)</span>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
         <VAlert
           v-if="errorMessage"
           type="error"


### PR DESCRIPTION
## Summary
- show password requirements as user types with red/green indicators
- mark required fields with asterisk and expand referral options
- validate password against new rules

## Testing
- `npm run lint` (fails: Cannot find module '/workspace/OSSPREY-FrontEnd-Server/.eslintrc.cjs')
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba1e120354832abbe28ea13f2a58f3