### PR TITLE
feat: add icons to auth buttons

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -98,9 +98,17 @@ const forgotPassword = () => {
           class="mb-4"
           :text="errorMessage"
         />
-        <VBtn type="submit" block size="large" class="mb-4 py-4">Login</VBtn>
+        <VBtn type="submit" block size="large" class="mb-4 py-4">
+          <template #prepend>
+            <VIcon icon="mdi-login" class="mr-2" />
+          </template>
+          Login
+        </VBtn>
       </VForm>
       <VBtn block variant="outlined" size="large" class="mb-4 py-4" to="/register">
+        <template #prepend>
+          <VIcon icon="mdi-account-plus" class="mr-2" />
+        </template>
         Register
       </VBtn>
       <VBtn block variant="text" class="mb-4" @click="forgotPassword">

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -172,9 +172,17 @@ const submit = async () => {
           class="mb-4"
           :text="successMessage"
         />
-        <VBtn type="submit" block size="large" class="mb-4 py-4">Register</VBtn>
+        <VBtn type="submit" block size="large" class="mb-4 py-4">
+          <template #prepend>
+            <VIcon icon="mdi-account-plus" class="mr-2" />
+          </template>
+          Register
+        </VBtn>
       </VForm>
       <VBtn block variant="outlined" size="large" class="mb-4 py-4" to="/">
+        <template #prepend>
+          <VIcon icon="mdi-login" class="mr-2" />
+        </template>
         Back to Login
       </VBtn>
     </VCard>


### PR DESCRIPTION
## Summary
- add login and register icons to auth buttons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find module '.eslintrc.cjs')

------
https://chatgpt.com/codex/tasks/task_e_68ba2a90c190832aa2483d79e14d6b9a