### PR TITLE
Track user login and logout events in frontend

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -50,6 +50,17 @@ const submit = async () => {
     }
     const userData = data.user || { name: data.name || email.value, email: email.value }
     localStorage.setItem('user', JSON.stringify(userData))
+
+    fetch(`${API_BASE}/api/track_login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ user_email: userData.email }),
+    }).catch(err => {
+      console.error('Failed to track login:', err)
+    })
+
     router.push('/dashboard')
   }
   catch (err) {

--- a/src/views/dashboard/Title.vue
+++ b/src/views/dashboard/Title.vue
@@ -36,12 +36,26 @@ onUnmounted(() => {
 const userName = computed(() => user.value?.name || user.value?.email || '');
 
 const logout = async () => {
+  const email = user.value?.email;
   try {
     await fetch(`${API_BASE}/api/logout`, { method: 'POST' });
   }
   catch {
     // ignore errors
   }
+
+  if (email) {
+    fetch(`${API_BASE}/api/track_logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ user_email: email }),
+    }).catch(err => {
+      console.error('Failed to track logout:', err);
+    });
+  }
+
   localStorage.removeItem('user');
   user.value = null;
   router.push('/login');


### PR DESCRIPTION
## Summary
- call backend `/api/track_login` when a user logs in
- send `/api/track_logout` when the user logs out

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find module '/workspace/OSSPREY-FrontEnd-Server/.eslintrc.cjs')*

------
https://chatgpt.com/codex/tasks/task_e_68ba8c942f40832a946ba206382b6776