### PR TITLE
Hide chat widget until user authenticated

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
     CardStatisticsHorizontal: typeof import('./src/@core/components/cards/CardStatisticsHorizontal.vue')['default']
     CardStatisticsVertical: typeof import('./src/@core/components/cards/CardStatisticsVertical.vue')['default']
     CardStatisticsWithImages: typeof import('./src/@core/components/cards/CardStatisticsWithImages.vue')['default']
+    ChatWidget: typeof import('./src/components/ChatWidget.vue')['default']
     MoreBtn: typeof import('./src/@core/components/MoreBtn.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,47 @@
 <script setup>
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+
 import ChatWidget from '@/components/ChatWidget.vue';
+
+const route = useRoute();
+const isAuthenticated = ref(false);
+
+const updateAuthenticationState = () => {
+  try {
+    isAuthenticated.value = Boolean(localStorage.getItem('user'));
+  }
+  catch (error) {
+    console.error('Failed to read authentication state', error);
+    isAuthenticated.value = false;
+  }
+};
+
+onMounted(() => {
+  updateAuthenticationState();
+  window.addEventListener('storage', updateAuthenticationState);
+  window.addEventListener('user-auth-changed', updateAuthenticationState);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('storage', updateAuthenticationState);
+  window.removeEventListener('user-auth-changed', updateAuthenticationState);
+});
+
+watch(
+  () => route.fullPath,
+  () => {
+    updateAuthenticationState();
+  },
+);
+
+const shouldShowChat = computed(() => isAuthenticated.value);
 </script>
 
 <template>
   <VApp>
     <RouterView />
-    <ChatWidget />
+    <ChatWidget v-if="shouldShowChat" />
     <!-- <UpgradeToPro /> -->
   </VApp>
 </template>

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -53,6 +53,7 @@ const submit = async () => {
     }
     const userData = data.user || { name: data.name || email.value, email: email.value }
     localStorage.setItem('user', JSON.stringify(userData))
+    window.dispatchEvent(new Event('user-auth-changed'))
 
     fetch(`${API_BASE}/api/track_login`, {
       method: 'POST',

--- a/src/views/dashboard/Title.vue
+++ b/src/views/dashboard/Title.vue
@@ -57,6 +57,7 @@ const logout = async () => {
   }
 
   localStorage.removeItem('user');
+  window.dispatchEvent(new Event('user-auth-changed'));
   user.value = null;
   router.push('/login');
 };


### PR DESCRIPTION
## Summary
- hide the chat widget until a stored user session is detected
- keep authentication state in sync by dispatching a custom event during login and logout
- update component type declarations for the chat widget

