### PR TITLE
Add repos overview page and navigation button

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview --port 5050",
     "lint": "eslint . -c .eslintrc.cjs --ext .ts,.js,.cjs,.vue,.tsx,.jsx",
+    "test": "node --test",
     "build:icons": "tsx src/plugins/iconify/build-icons.js",
     "postinstall": "npm run build:icons"
   },

--- a/src/layouts/components/AllReposButton.vue
+++ b/src/layouts/components/AllReposButton.vue
@@ -1,0 +1,34 @@
+<script setup>
+import { navigateToRepos } from '@/utils/navigation';
+
+const router = useRouter();
+
+const goToRepos = () => {
+  navigateToRepos(router);
+};
+
+defineExpose({
+  goToRepos,
+});
+</script>
+
+<template>
+  <VTooltip
+    text="All Repos"
+    location="bottom"
+  >
+    <template #activator="{ props }">
+      <VBtn
+        v-bind="props"
+        class="ms-2 font-weight-medium"
+        color="primary"
+        variant="tonal"
+        aria-label="All Repos"
+        style="text-transform: none;"
+        @click="goToRepos"
+      >
+        All Repos
+      </VBtn>
+    </template>
+  </VTooltip>
+</template>

--- a/src/layouts/components/NavbarActions.vue
+++ b/src/layouts/components/NavbarActions.vue
@@ -1,0 +1,94 @@
+<script setup>
+import NavbarThemeSwitcher from '@/layouts/components/NavbarThemeSwitcher.vue';
+import AllReposButton from '@/layouts/components/AllReposButton.vue';
+
+const user = ref(null);
+const router = useRouter();
+const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '');
+
+const loadUserFromStorage = () => {
+  try {
+    const stored = localStorage.getItem('user');
+    user.value = stored ? JSON.parse(stored) : null;
+  }
+  catch {
+    user.value = null;
+  }
+};
+
+const handleStorage = event => {
+  if (!event || event.key === 'user')
+    loadUserFromStorage();
+};
+
+onMounted(() => {
+  loadUserFromStorage();
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener('user-auth-changed', loadUserFromStorage);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('storage', handleStorage);
+  window.removeEventListener('user-auth-changed', loadUserFromStorage);
+});
+
+const userName = computed(() => user.value?.name || user.value?.email || '');
+
+const logout = async () => {
+  const email = user.value?.email;
+
+  try {
+    await fetch(`${API_BASE}/api/logout`, { method: 'POST' });
+  }
+  catch {
+    // ignore errors
+  }
+
+  if (email) {
+    fetch(`${API_BASE}/api/track_logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ user_email: email }),
+    }).catch(err => {
+      console.error('Failed to track logout:', err);
+    });
+  }
+
+  localStorage.removeItem('user');
+  window.dispatchEvent(new Event('user-auth-changed'));
+  user.value = null;
+  router.push('/');
+};
+</script>
+
+<template>
+  <div class="navbar-actions">
+    <NavbarThemeSwitcher />
+    <AllReposButton />
+
+    <VTooltip v-if="user" :text="userName" location="bottom">
+      <template #activator="{ props }">
+        <VBtn v-bind="props" icon class="ms-2" aria-label="User account">
+          <VIcon icon="bx-user" />
+        </VBtn>
+      </template>
+    </VTooltip>
+
+    <VTooltip v-if="user" text="Log Out" location="bottom">
+      <template #activator="{ props }">
+        <VBtn v-bind="props" icon class="ms-2" aria-label="Log out" @click="logout">
+          <VIcon icon="bx-log-out" />
+        </VBtn>
+      </template>
+    </VTooltip>
+  </div>
+</template>
+
+<style scoped>
+.navbar-actions {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/src/layouts/components/NavbarBranding.vue
+++ b/src/layouts/components/NavbarBranding.vue
@@ -1,0 +1,53 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue';
+
+const isMobileView = ref(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
+
+const updateViewport = () => {
+  if (typeof window === 'undefined')
+    return;
+
+  isMobileView.value = window.innerWidth < 768;
+};
+
+onMounted(() => {
+  updateViewport();
+  window.addEventListener('resize', updateViewport);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateViewport);
+});
+</script>
+
+<template>
+  <div class="navbar-branding" aria-label="OSSPREY branding">
+    <img
+      src="/ospex-logo.png"
+      alt="OSSPREY logo"
+      class="navbar-branding__logo"
+    />
+    <span class="navbar-branding__name">
+      {{ isMobileView ? 'OSSPREY' : 'OSSPREY (Open Source Software PRojEct sustainabilitY tracker)' }}
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.navbar-branding {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.navbar-branding__logo {
+  height: 32px;
+  width: auto;
+}
+
+.navbar-branding__name {
+  font-weight: 600;
+  color: rgb(var(--v-theme-primary));
+  line-height: 1.25;
+}
+</style>

--- a/src/layouts/components/NavbarBranding.vue
+++ b/src/layouts/components/NavbarBranding.vue
@@ -49,5 +49,7 @@ onUnmounted(() => {
   font-weight: 600;
   color: rgb(var(--v-theme-primary));
   line-height: 1.25;
+  font-size: 1.25rem;
+  text-align: center;
 }
 </style>

--- a/src/pages/repos.vue
+++ b/src/pages/repos.vue
@@ -1,5 +1,6 @@
 <script setup>
 import NavbarActions from '@/layouts/components/NavbarActions.vue';
+import NavbarBranding from '@/layouts/components/NavbarBranding.vue';
 import ReposTable from '@/views/repos/ReposTable.vue';
 
 const pendingRepos = [
@@ -7,18 +8,21 @@ const pendingRepos = [
     repoName: 'ossprey/metrics-pipeline',
     startTime: '2025-10-02 10:12',
     completionTime: null,
+    estimatedProcessingTime: '17 minutes 45 seconds',
     status: 'pending',
   },
   {
     repoName: 'apache/incubator-ex',
     startTime: '2025-10-02 09:55',
     completionTime: null,
+    estimatedProcessingTime: '22 minutes 5 seconds',
     status: 'pending',
   },
   {
     repoName: 'eclipse/foundation-tools',
     startTime: '2025-10-01 21:18',
     completionTime: null,
+    estimatedProcessingTime: '31 minutes 12 seconds',
     status: 'pending',
   },
 ];
@@ -47,30 +51,39 @@ const processedRepos = [
 
 <template>
   <VContainer fluid class="py-6 repos-page">
-    <div class="repos-header">
-      <h1 class="text-h4 font-weight-bold mb-0">All Repos</h1>
+    <header class="repos-topbar" role="banner">
+      <NavbarBranding />
       <NavbarActions />
-    </div>
+    </header>
 
-    <ReposTable title="Pending Repos" :rows="pendingRepos" class="mt-8" />
-    <ReposTable title="Processed Repos" :rows="processedRepos" class="mt-8" />
+    <h1 class="text-h4 font-weight-bold mt-8">All Repos</h1>
+
+    <ReposTable
+      title="Pending Repos"
+      :rows="pendingRepos"
+      time-column-label="Estimated Processing Time"
+      time-field="estimatedProcessingTime"
+      class="mt-8"
+    />
+    <ReposTable
+      title="Processed Repos"
+      :rows="processedRepos"
+      class="mt-8"
+    />
   </VContainer>
 </template>
 
 <style scoped>
 .repos-page {
-  max-width: 1200px;
+  max-width: 1280px;
+  margin: 0 auto;
 }
 
-.repos-header {
+.repos-topbar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-}
-
-.repos-header h1 {
-  flex: 1 1 auto;
+  gap: 1.5rem;
 }
 </style>

--- a/src/pages/repos.vue
+++ b/src/pages/repos.vue
@@ -56,7 +56,10 @@ const processedRepos = [
       <NavbarActions />
     </header>
 
-    <h1 class="text-h4 font-weight-bold mt-8">All Repos</h1>
+    <div class="repos-heading mt-8">
+      <h1 class="text-h4 font-weight-bold mb-0">All Repos</h1>
+      <p class="repos-heading__note">This page is currently under development.</p>
+    </div>
 
     <ReposTable
       title="Pending Repos"
@@ -85,5 +88,18 @@ const processedRepos = [
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
+}
+
+.repos-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.repos-heading__note {
+  font-size: 1.1rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  margin: 0;
 }
 </style>

--- a/src/pages/repos.vue
+++ b/src/pages/repos.vue
@@ -1,0 +1,76 @@
+<script setup>
+import NavbarActions from '@/layouts/components/NavbarActions.vue';
+import ReposTable from '@/views/repos/ReposTable.vue';
+
+const pendingRepos = [
+  {
+    repoName: 'ossprey/metrics-pipeline',
+    startTime: '2025-10-02 10:12',
+    completionTime: null,
+    status: 'pending',
+  },
+  {
+    repoName: 'apache/incubator-ex',
+    startTime: '2025-10-02 09:55',
+    completionTime: null,
+    status: 'pending',
+  },
+  {
+    repoName: 'eclipse/foundation-tools',
+    startTime: '2025-10-01 21:18',
+    completionTime: null,
+    status: 'pending',
+  },
+];
+
+const processedRepos = [
+  {
+    repoName: 'nafiz/elta-ai-agentic',
+    startTime: '2025-09-30 14:03',
+    completionTime: '2025-09-30 14:29',
+    status: 'processed',
+  },
+  {
+    repoName: 'uc-davis/decal-lab-site',
+    startTime: '2025-09-29 11:47',
+    completionTime: '2025-09-29 12:02',
+    status: 'processed',
+  },
+  {
+    repoName: 'ossprey/frontend',
+    startTime: '2025-09-28 16:20',
+    completionTime: '2025-09-28 16:41',
+    status: 'processed',
+  },
+];
+</script>
+
+<template>
+  <VContainer fluid class="py-6 repos-page">
+    <div class="repos-header">
+      <h1 class="text-h4 font-weight-bold mb-0">All Repos</h1>
+      <NavbarActions />
+    </div>
+
+    <ReposTable title="Pending Repos" :rows="pendingRepos" class="mt-8" />
+    <ReposTable title="Processed Repos" :rows="processedRepos" class="mt-8" />
+  </VContainer>
+</template>
+
+<style scoped>
+.repos-page {
+  max-width: 1200px;
+}
+
+.repos-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.repos-header h1 {
+  flex: 1 1 auto;
+}
+</style>

--- a/src/pages/repos.vue
+++ b/src/pages/repos.vue
@@ -99,7 +99,7 @@ const processedRepos = [
 
 .repos-heading__note {
   font-size: 1.1rem;
-  color: rgba(var(--v-theme-on-surface), 0.7);
+  color: rgb(var(--v-theme-error));
   margin: 0;
 }
 </style>

--- a/src/plugins/router/routes.js
+++ b/src/plugins/router/routes.js
@@ -26,4 +26,15 @@ export const routes = [
       },
     ],
   },
+  {
+    path: '/repos',
+    component: () => import('@/layouts/default.vue'),
+    children: [
+      {
+        path: '',
+        name: 'Repos',
+        component: () => import('@/pages/repos.vue'),
+      },
+    ],
+  },
 ];

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -1,0 +1,12 @@
+/**
+ * Navigate to the repos overview route using the provided router instance.
+ *
+ * @param {{ push: (location: string | Record<string, any>) => any }} router
+ * @returns {any}
+ */
+export const navigateToRepos = router => {
+  if (!router || typeof router.push !== 'function')
+    throw new TypeError('A Vue Router instance with a push method is required.');
+
+  return router.push('/repos');
+};

--- a/src/views/dashboard/Title.vue
+++ b/src/views/dashboard/Title.vue
@@ -1,23 +1,6 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue';
 import NavbarActions from '@/layouts/components/NavbarActions.vue';
-
-// Reactive variable to track viewport width
-const isMobileView = ref(window.innerWidth < 768);
-
-// Function to update viewport state
-const updateViewport = () => {
-  isMobileView.value = window.innerWidth < 768;
-};
-
-// Add and remove event listener on component lifecycle
-onMounted(() => {
-  window.addEventListener('resize', updateViewport);
-});
-
-onUnmounted(() => {
-  window.removeEventListener('resize', updateViewport);
-});
+import NavbarBranding from '@/layouts/components/NavbarBranding.vue';
 </script>
 
 <template>
@@ -26,15 +9,8 @@ onUnmounted(() => {
       
       <!-- Logo + Title -->
       <div class="title-container">
-        <VCardTitle class="text-primary font-weight-bold d-flex align-center mb-0">
-          <img
-            src="/ospex-logo.png"
-            alt="OSPEx Logo"
-            style="height: 32px; width: auto; margin-right: 10px;"
-          />
-
-          <span v-if="isMobileView">OSSPREY</span>
-          <span v-else>OSSPREY (Open Source Software PRojEct sustainabilitY tracker)</span>
+        <VCardTitle class="d-flex align-center mb-0">
+          <NavbarBranding />
         </VCardTitle>
       </div>
 

--- a/src/views/dashboard/Title.vue
+++ b/src/views/dashboard/Title.vue
@@ -1,11 +1,6 @@
 <script setup>
-import { ref, onMounted, onUnmounted, computed } from 'vue';
-import { useRouter } from 'vue-router';
-import NavbarThemeSwitcher from '@/layouts/components/NavbarThemeSwitcher.vue';
-
-const user = ref(null);
-const router = useRouter();
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '');
+import { ref, onMounted, onUnmounted } from 'vue';
+import NavbarActions from '@/layouts/components/NavbarActions.vue';
 
 // Reactive variable to track viewport width
 const isMobileView = ref(window.innerWidth < 768);
@@ -18,49 +13,11 @@ const updateViewport = () => {
 // Add and remove event listener on component lifecycle
 onMounted(() => {
   window.addEventListener('resize', updateViewport);
-  const stored = localStorage.getItem('user');
-  if (stored) {
-    try {
-      user.value = JSON.parse(stored);
-    }
-    catch {
-      // ignore parse errors
-    }
-  }
 });
 
 onUnmounted(() => {
   window.removeEventListener('resize', updateViewport);
 });
-
-const userName = computed(() => user.value?.name || user.value?.email || '');
-
-const logout = async () => {
-  const email = user.value?.email;
-  try {
-    await fetch(`${API_BASE}/api/logout`, { method: 'POST' });
-  }
-  catch {
-    // ignore errors
-  }
-
-  if (email) {
-    fetch(`${API_BASE}/api/track_logout`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ user_email: email }),
-    }).catch(err => {
-      console.error('Failed to track logout:', err);
-    });
-  }
-
-  localStorage.removeItem('user');
-  window.dispatchEvent(new Event('user-auth-changed'));
-  user.value = null;
-  router.push('/');
-};
 </script>
 
 <template>
@@ -83,23 +40,7 @@ const logout = async () => {
 
       <!-- Action Icons -->
       <div class="actions-container">
-        <NavbarThemeSwitcher />
-
-        <VTooltip v-if="user" :text="userName" location="bottom">
-          <template #activator="{ props }">
-            <VBtn v-bind="props" icon class="ms-2">
-              <VIcon icon="bx-user" />
-            </VBtn>
-          </template>
-        </VTooltip>
-
-        <VTooltip v-if="user" text="Log Out" location="bottom">
-          <template #activator="{ props }">
-            <VBtn v-bind="props" icon class="ms-2" @click="logout">
-              <VIcon icon="bx-log-out" />
-            </VBtn>
-          </template>
-        </VTooltip>
+        <NavbarActions />
       </div>
     </VCardText>
   </VCard>

--- a/src/views/repos/ReposTable.vue
+++ b/src/views/repos/ReposTable.vue
@@ -6,6 +6,7 @@ import { computed } from 'vue';
  * @property {string} repoName
  * @property {string} startTime
  * @property {string|null} [completionTime]
+ * @property {string} [estimatedProcessingTime]
  * @property {'pending' | 'processed'} status
  */
 
@@ -17,6 +18,14 @@ const props = defineProps({
   rows: {
     type: Array,
     default: () => [],
+  },
+  timeColumnLabel: {
+    type: String,
+    default: 'Completion Time',
+  },
+  timeField: {
+    type: String,
+    default: 'completionTime',
   },
 });
 
@@ -33,6 +42,15 @@ const normaliseDateString = value => {
 const sortedRows = computed(() => {
   return [...props.rows].sort((a, b) => normaliseDateString(b.startTime) - normaliseDateString(a.startTime));
 });
+
+const resolveTimeValue = row => {
+  const value = row?.[props.timeField];
+
+  if (value === null || value === undefined || value === '')
+    return '—';
+
+  return value;
+};
 </script>
 
 <template>
@@ -45,14 +63,14 @@ const sortedRows = computed(() => {
           <tr>
             <th scope="col">Repo Name</th>
             <th scope="col">Task Initiation Time</th>
-            <th scope="col">Completion Time</th>
+            <th scope="col">{{ timeColumnLabel }}</th>
           </tr>
         </thead>
         <tbody v-if="sortedRows.length">
           <tr v-for="row in sortedRows" :key="`${row.repoName}-${row.startTime}`">
             <td>{{ row.repoName }}</td>
             <td>{{ row.startTime }}</td>
-            <td>{{ row.completionTime ?? '—' }}</td>
+            <td>{{ resolveTimeValue(row) }}</td>
           </tr>
         </tbody>
         <tbody v-else>
@@ -70,22 +88,25 @@ const sortedRows = computed(() => {
   margin-top: 2.5rem;
 }
 
+
 .table-wrapper {
   overflow-x: auto;
-  border-radius: 12px;
-  background-color: rgba(var(--v-theme-surface), 0.9);
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  background-color: rgba(var(--v-theme-surface), 0.95);
+  box-shadow: 0 6px 24px rgba(15, 23, 42, 0.12);
+  padding: 1rem;
 }
 
 .repos-table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 480px;
+  min-width: 640px;
+  font-size: 1.05rem;
 }
 
 .repos-table th,
 .repos-table td {
-  padding: 0.75rem 1rem;
+  padding: 1.1rem 1.5rem;
   text-align: left;
   border-bottom: 1px solid rgba(var(--v-theme-outline-variant), 0.6);
   word-break: break-word;
@@ -94,6 +115,7 @@ const sortedRows = computed(() => {
 .repos-table thead th {
   font-weight: 600;
   background-color: rgba(var(--v-theme-surface-variant), 0.6);
+  font-size: 1.125rem;
 }
 
 .repos-table tbody tr:last-child td {
@@ -102,7 +124,18 @@ const sortedRows = computed(() => {
 
 .empty-state {
   text-align: center;
-  padding: 1.5rem;
+  padding: 1.75rem;
   color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+@media (max-width: 960px) {
+  .repos-table {
+    font-size: 0.95rem;
+  }
+
+  .repos-table th,
+  .repos-table td {
+    padding: 0.85rem 1.1rem;
+  }
 }
 </style>

--- a/src/views/repos/ReposTable.vue
+++ b/src/views/repos/ReposTable.vue
@@ -1,0 +1,108 @@
+<script setup>
+import { computed } from 'vue';
+
+/**
+ * @typedef {Object} RepoRow
+ * @property {string} repoName
+ * @property {string} startTime
+ * @property {string|null} [completionTime]
+ * @property {'pending' | 'processed'} status
+ */
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  rows: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const normaliseDateString = value => {
+  if (!value)
+    return Number.NEGATIVE_INFINITY;
+
+  const normalised = value.replace(' ', 'T');
+  const timestamp = Date.parse(normalised);
+
+  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+};
+
+const sortedRows = computed(() => {
+  return [...props.rows].sort((a, b) => normaliseDateString(b.startTime) - normaliseDateString(a.startTime));
+});
+</script>
+
+<template>
+  <section class="repos-section">
+    <h2 class="text-h5 font-weight-medium mb-4">{{ title }}</h2>
+
+    <div class="table-wrapper" role="region" :aria-label="`${title} table`">
+      <table class="repos-table">
+        <thead>
+          <tr>
+            <th scope="col">Repo Name</th>
+            <th scope="col">Task Initiation Time</th>
+            <th scope="col">Completion Time</th>
+          </tr>
+        </thead>
+        <tbody v-if="sortedRows.length">
+          <tr v-for="row in sortedRows" :key="`${row.repoName}-${row.startTime}`">
+            <td>{{ row.repoName }}</td>
+            <td>{{ row.startTime }}</td>
+            <td>{{ row.completionTime ?? '—' }}</td>
+          </tr>
+        </tbody>
+        <tbody v-else>
+          <tr>
+            <td colspan="3" class="empty-state">No items to show.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.repos-section + .repos-section {
+  margin-top: 2.5rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: rgba(var(--v-theme-surface), 0.9);
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
+}
+
+.repos-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+}
+
+.repos-table th,
+.repos-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(var(--v-theme-outline-variant), 0.6);
+  word-break: break-word;
+}
+
+.repos-table thead th {
+  font-weight: 600;
+  background-color: rgba(var(--v-theme-surface-variant), 0.6);
+}
+
+.repos-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 1.5rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+</style>

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { navigateToRepos } from '../src/utils/navigation.js';
+
+const createMockRouter = () => {
+  const calls = [];
+  return {
+    calls,
+    push: location => {
+      calls.push(location);
+      return Promise.resolve(location);
+    },
+  };
+};
+
+test('navigateToRepos pushes the /repos route', async () => {
+  const router = createMockRouter();
+  await navigateToRepos(router);
+
+  assert.deepEqual(router.calls, ['/repos']);
+});
+
+test('navigateToRepos throws when router is invalid', () => {
+  assert.throws(() => navigateToRepos(null), {
+    name: 'TypeError',
+  });
+});

--- a/tests/repos-table.test.js
+++ b/tests/repos-table.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { parse, compileScript, compileTemplate } from '@vue/compiler-sfc';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const loadDescriptor = async relativePath => {
+  const filepath = resolve(__dirname, '..', relativePath);
+  const source = await readFile(filepath, 'utf8');
+  const { descriptor } = parse(source, { filename: filepath });
+  return { descriptor, filepath };
+};
+
+const loadComponent = async relativePath => {
+  const { descriptor, filepath } = await loadDescriptor(relativePath);
+  const script = compileScript(descriptor, { id: 'repo-table-test' });
+  const template = compileTemplate({ source: descriptor.template?.content ?? '', id: 'repo-table-test', filename: filepath });
+  const transformedScript = script.content.replace('export default', 'const __sfc__ =');
+  const moduleCode = `\n${transformedScript}\n${template.code}\n__sfc__.render = render;\nexport default __sfc__;\n`;
+  const tempDir = await mkdtemp(join(__dirname, '.repos-table-'));
+  const modulePath = join(tempDir, 'component.mjs');
+  await writeFile(modulePath, moduleCode, 'utf8');
+  const module = await import(pathToFileURL(modulePath).href);
+  await rm(tempDir, { recursive: true, force: true });
+  return { component: module.default, descriptor };
+};
+
+test('ReposTable sorts rows by most recent start time', async () => {
+  const { component } = await loadComponent('src/views/repos/ReposTable.vue');
+  const rows = [
+    { repoName: 'older/repo', startTime: '2025-09-01 08:00', completionTime: '2025-09-01 09:00', status: 'processed' },
+    { repoName: 'newer/repo', startTime: '2025-10-01 08:00', completionTime: null, status: 'pending' },
+  ];
+
+  const setupResult = await component.setup({ title: 'Pending', rows }, { expose() {} });
+  const sorted = setupResult.sortedRows.value.map(item => item.repoName);
+
+  assert.deepEqual(sorted, ['newer/repo', 'older/repo']);
+});
+
+test('ReposTable template includes headers, empty state, and pending dash copy', async () => {
+  const { descriptor } = await loadComponent('src/views/repos/ReposTable.vue');
+  const template = descriptor.template?.content ?? '';
+
+  assert.ok(template.includes('Repo Name'), 'Repo Name header should be present');
+  assert.ok(template.includes('Task Initiation Time'), 'Task Initiation Time header should be present');
+  assert.ok(template.includes('Completion Time'), 'Completion Time header should be present');
+  assert.ok(template.includes('No items to show.'), 'Empty state copy should be present');
+  assert.ok(template.includes("completionTime ?? '—'"), 'Pending completion should render as an em dash');
+});

--- a/tests/repos-table.test.js
+++ b/tests/repos-table.test.js
@@ -45,10 +45,12 @@ test('ReposTable sorts rows by most recent start time', async () => {
 test('ReposTable template includes headers, empty state, and pending dash copy', async () => {
   const { descriptor } = await loadComponent('src/views/repos/ReposTable.vue');
   const template = descriptor.template?.content ?? '';
+  const script = descriptor.scriptSetup?.content ?? '';
 
   assert.ok(template.includes('Repo Name'), 'Repo Name header should be present');
   assert.ok(template.includes('Task Initiation Time'), 'Task Initiation Time header should be present');
-  assert.ok(template.includes('Completion Time'), 'Completion Time header should be present');
+  assert.ok(template.includes('{{ timeColumnLabel }}'), 'Dynamic time column label should be present');
   assert.ok(template.includes('No items to show.'), 'Empty state copy should be present');
-  assert.ok(template.includes("completionTime ?? '—'"), 'Pending completion should render as an em dash');
+  assert.ok(template.includes('resolveTimeValue(row)'), 'Resolver helper should be wired into the template');
+  assert.ok(script.includes("return '—'"), 'Pending completion should render as an em dash');
 });


### PR DESCRIPTION
## Summary
- add a reusable navbar actions component with an All Repos button that links to the new overview
- create the Repos overview route and page that displays pending and processed repositories in responsive tables fed by dummy data
- introduce a navigation helper and node-based unit tests covering the All Repos navigation flow and table presentation logic, wiring npm test to the node test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df2f1021bc832a8ed7351d6d54aa1e