### PR TITLE
Add /login alias to router for inactivity logout redirect

### DIFF
--- a/src/plugins/router/routes.js
+++ b/src/plugins/router/routes.js
@@ -7,6 +7,7 @@ export const routes = [
         path: '',
         name: 'Login',
         component: () => import('@/pages/login.vue'),
+        alias: '/login',
       },
       {
         path: 'register',


### PR DESCRIPTION
## Summary
- add a /login alias to the login route so inactivity auto-logout redirects to the proper page
- keep the login experience accessible for the existing root path

## Testing
- npm run lint *(fails: missing .eslintrc.cjs configuration file)*