### PR TITLE
Add frontend view tracking and display counts

### DIFF
--- a/src/layouts/components/Footer.vue
+++ b/src/layouts/components/Footer.vue
@@ -1,7 +1,32 @@
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { VIEW_RECORDED_EVENT, fetchViewCount } from '@/utils/viewTracking'
+
+const viewCountText = ref('Loading...')
+
+const loadViewCount = async () => {
+  const count = await fetchViewCount()
+  viewCountText.value = typeof count === 'number' ? count.toLocaleString() : 'N/A'
+}
+
+const handleViewRecorded = () => {
+  loadViewCount()
+}
+
+onMounted(() => {
+  loadViewCount()
+  window.addEventListener(VIEW_RECORDED_EVENT, handleViewRecorded)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener(VIEW_RECORDED_EVENT, handleViewRecorded)
+})
+</script>
+
 <template>
   <div class="footer-container">
     <span class="footer-text">
-      Developed at the 
+      Developed at the
       <a href="https://decallab.cs.ucdavis.edu/join/" target="_blank" rel="noopener noreferrer" class="footer-link">DECAL Lab</a>, 
       in the CS Department, UC Davis, by 
       <strong>
@@ -29,6 +54,10 @@
 
     <span class="footer-text">
       OSSPREY is a tool to support sustainable open-source development. It provides direct analytics of project metrics, temporal AI-based sustainability forecasts, and evidence-based recommendations to improve long-term viability. [<a href="https://oss-prey.github.io/OSSPREY-Website/" target="_blank" rel="noopener noreferrer" class="footer-link">Website</a>] [<a href="https://github.com/orgs/OSS-PREY/repositories" target="_blank" rel="noopener noreferrer" class="footer-link">GitHub</a>]
+    </span>
+
+    <span class="footer-text">
+      OSSPREY Views: {{ viewCountText }}
     </span>
   </div>
 </template>

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'; // Import ref to manage collapse state
+import { onMounted, ref } from 'vue'; // Import ref to manage collapse state
 import Actionables from '@/views/dashboard/Actionables.vue';
 import GraduationForecast from '@/views/dashboard/GraduationForecast.vue';
 import SocialNetworkNode from '@/views/dashboard/SocialNetworkNode.vue';
@@ -16,12 +16,17 @@ import CommitsPerCommitters from '@/views/dashboard/CommitsPerCommitters.vue';
 import SeeAdvancedAnalytics from '@/views/dashboard/SeeAdvancedAnalytics.vue';
 import Committers from '@/views/dashboard/Committers.vue';
 import Title from '@/views/dashboard/Title.vue';
+import { recordView } from '@/utils/viewTracking';
 const isCollapsed = ref(true); // Manage collapse state here
 
 // Function to toggle the collapse state for all cards
 const toggleCollapse = () => {
   isCollapsed.value = !isCollapsed.value;
 };
+
+onMounted(() => {
+  recordView();
+});
 </script>
 
 <template>

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { recordView } from '@/utils/viewTracking'
 
 const email = ref('')
 const password = ref('')
@@ -15,6 +16,8 @@ const route = useRoute()
 const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
 
 onMounted(() => {
+  recordView()
+
   const msg = typeof route.query.message === 'string' ? route.query.message : ''
   if (msg) successMessage.value = msg
   // Clear the query so the message doesn't persist on navigation

--- a/src/utils/viewTracking.js
+++ b/src/utils/viewTracking.js
@@ -1,0 +1,51 @@
+const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+
+export const VIEW_RECORDED_EVENT = 'ossprey-view-recorded'
+
+export const recordView = async () => {
+  try {
+    const response = await fetch(`${API_BASE}/api/record_view`, {
+      method: 'POST',
+    })
+
+    if (!response.ok) {
+      console.error(`Failed to record view: ${response.status} ${response.statusText}`)
+      return false
+    }
+
+    window.dispatchEvent(new CustomEvent(VIEW_RECORDED_EVENT))
+    return true
+  }
+  catch (error) {
+    console.error('Failed to record view:', error)
+    return false
+  }
+}
+
+export const fetchViewCount = async () => {
+  try {
+    const response = await fetch(`${API_BASE}/api/view_count`)
+
+    if (!response.ok) {
+      console.error(`Failed to fetch view count: ${response.status} ${response.statusText}`)
+      return null
+    }
+
+    const data = await response.json().catch(() => null)
+
+    if (typeof data === 'number')
+      return data
+
+    if (data && typeof data.count === 'number')
+      return data.count
+
+    if (data && typeof data.view_count === 'number')
+      return data.view_count
+
+    return null
+  }
+  catch (error) {
+    console.error('Failed to fetch view count:', error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared view tracking utility that records page loads and retrieves totals
- trigger view recording when the login and dashboard pages mount so backend counters stay in sync
- surface the running OSSPREY view count in the layout footer with automatic refresh after each recorded view

## Testing
- npm run lint *(fails: missing `/workspace/OSSPREY-FrontEnd-Server/.eslintrc.cjs` in repository)*