### PR TITLE
Display hosted user count in footer

### DIFF
--- a/src/layouts/components/Footer.vue
+++ b/src/layouts/components/Footer.vue
@@ -1,12 +1,18 @@
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
-import { VIEW_RECORDED_EVENT, fetchViewCount } from '@/utils/viewTracking'
+import { VIEW_RECORDED_EVENT, fetchUserCount, fetchViewCount } from '@/utils/viewTracking'
 
 const viewCountText = ref('Loading...')
+const userCountText = ref('Loading...')
 
 const loadViewCount = async () => {
   const count = await fetchViewCount()
   viewCountText.value = typeof count === 'number' ? count.toLocaleString() : 'N/A'
+}
+
+const loadUserCount = async () => {
+  const count = await fetchUserCount()
+  userCountText.value = typeof count === 'number' ? count.toLocaleString() : 'N/A'
 }
 
 const handleViewRecorded = () => {
@@ -15,6 +21,7 @@ const handleViewRecorded = () => {
 
 onMounted(() => {
   loadViewCount()
+  loadUserCount()
   window.addEventListener(VIEW_RECORDED_EVENT, handleViewRecorded)
 })
 
@@ -56,8 +63,10 @@ onBeforeUnmount(() => {
       OSSPREY is a tool to support sustainable open-source development. It provides direct analytics of project metrics, temporal AI-based sustainability forecasts, and evidence-based recommendations to improve long-term viability. [<a href="https://oss-prey.github.io/OSSPREY-Website/" target="_blank" rel="noopener noreferrer" class="footer-link">Website</a>] [<a href="https://github.com/orgs/OSS-PREY/repositories" target="_blank" rel="noopener noreferrer" class="footer-link">GitHub</a>]
     </span>
 
-    <span class="footer-text">
+    <span class="footer-text footer-metrics">
       <strong>OSSPREY Views</strong>: {{ viewCountText }}
+      <span aria-hidden="true" class="footer-metrics__separator">|</span>
+      <strong>Users</strong>: {{ userCountText }}
     </span>
   </div>
 </template>
@@ -91,5 +100,17 @@ onBeforeUnmount(() => {
 
 .footer-link:hover {
   text-decoration: underline;
+}
+
+.footer-metrics {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.footer-metrics__separator {
+  opacity: 0.5;
 }
 </style>

--- a/src/utils/viewTracking.js
+++ b/src/utils/viewTracking.js
@@ -49,3 +49,31 @@ export const fetchViewCount = async () => {
     return null
   }
 }
+
+export const fetchUserCount = async () => {
+  try {
+    const response = await fetch(`${API_BASE}/api/users`)
+
+    if (!response.ok) {
+      console.error(`Failed to fetch user count: ${response.status} ${response.statusText}`)
+      return null
+    }
+
+    const data = await response.json().catch(() => null)
+
+    if (!data || !Array.isArray(data.users))
+      return null
+
+    const uniqueEmails = new Set(
+      data.users
+        .map((user) => (user && typeof user.email === 'string' ? user.email.trim().toLowerCase() : null))
+        .filter(Boolean),
+    )
+
+    return uniqueEmails.size
+  }
+  catch (error) {
+    console.error('Failed to fetch user count:', error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- add a user-count fetcher that uses the hosted API and de-duplicates users by email
- render the user total next to the OSSPREY view count with responsive styling

## Testing
- npm run build