### PR TITLE
Display empty-state messaging when monthly data is missing

### DIFF
--- a/src/views/dashboard/Actionables.vue
+++ b/src/views/dashboard/Actionables.vue
@@ -34,7 +34,7 @@
 
     <!-- Table for Actionables -->
     <VCardText>
-      <div class="table-container">
+      <div v-if="hasActionables" class="table-container">
         <table class="table table-bordered">
           <tbody>
             <template v-for="(actionable, index) in sortedActionables" :key="index">
@@ -57,6 +57,9 @@
             </template>
           </tbody>
         </table>
+      </div>
+      <div v-else-if="shouldShowActionableEmptyState" class="empty-state">
+        No data available for this month.
       </div>
     </VCardText>
   </VCard>
@@ -124,6 +127,13 @@ const sortedActionables = computed(() => {
 
 });
 // ---------------------------------------------------------------------------
+
+const hasActionables = computed(() => Array.isArray(sortedActionables.value) && sortedActionables.value.length > 0);
+
+const shouldShowActionableEmptyState = computed(() => {
+  const hasMonth = projectStore.selectedMonth !== null && projectStore.selectedMonth !== undefined;
+  return hasMonth && !hasActionables.value;
+});
 </script>
 
 <style scoped>
@@ -226,5 +236,15 @@ const sortedActionables = computed(() => {
 .table-container {
   overflow-x: auto;
   padding-bottom: 10px;
+}
+
+.empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  font-weight: 500;
+  color: #6b6b6b;
+  text-align: center;
 }
 </style>

--- a/src/views/dashboard/SocialNetwork.vue
+++ b/src/views/dashboard/SocialNetwork.vue
@@ -13,13 +13,8 @@
         <span class="loading-text">Loading Sankey diagram...</span>
       </div>
       <!-- No Data Message -->
-      <div
-        v-if="!projectStore.socialNetLoading && !projectStore.socialNetError &&
-             (!projectStore.socialNetData || projectStore.socialNetData.length === 0) &&
-             projectStore.selectedProject && projectStore.selectedMonth"
-        class="overlay"
-      >
-        No social network data available for the selected month.
+      <div v-if="shouldShowSocialNoData" class="overlay">
+        No data available for this month.
       </div>
       <!-- Prompt to Select a Project -->
       <div v-if="!projectStore.selectedProject" class="overlay">
@@ -55,6 +50,15 @@ const currentSocialData = computed(() => {
     }
   }
   return [];
+});
+
+const shouldShowSocialNoData = computed(() => {
+  const hasProject = !!projectStore.selectedProject;
+  const hasMonth = projectStore.selectedMonth !== null && projectStore.selectedMonth !== undefined;
+  if (!hasProject || !hasMonth) return false;
+  if (projectStore.socialNetLoading || projectStore.socialNetError) return false;
+  const data = currentSocialData.value;
+  return !data || data.length === 0;
 });
 
 function reduceTheEmails(inputArray) {

--- a/src/views/dashboard/TechnicalNetwork.vue
+++ b/src/views/dashboard/TechnicalNetwork.vue
@@ -13,13 +13,8 @@
         <span class="loading-text">Loading Sankey diagram...</span>
       </div>
       <!-- No Data Message -->
-      <div
-        v-if="!projectStore.techNetLoading && !projectStore.techNetError &&
-             (!projectStore.techNetData || projectStore.techNetData.length === 0) &&
-             projectStore.selectedProject && projectStore.selectedMonth"
-        class="overlay"
-      >
-        No technical network data available for the selected month.
+      <div v-if="shouldShowTechNoData" class="overlay">
+        No data available for this month.
       </div>
       <!-- Prompt to Select a Project -->
       <div v-if="!projectStore.selectedProject" class="overlay">
@@ -30,7 +25,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onUnmounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import * as d3 from 'd3';
 import { sankey, sankeyCenter, sankeyLinkHorizontal } from 'd3-sankey';
 import { useProjectStore } from '@/stores/projectStore';
@@ -55,6 +50,15 @@ const currentTechData = computed(() => {
     }
   }
   return [];
+});
+
+const shouldShowTechNoData = computed(() => {
+  const hasProject = !!projectStore.selectedProject;
+  const hasMonth = projectStore.selectedMonth !== null && projectStore.selectedMonth !== undefined;
+  if (!hasProject || !hasMonth) return false;
+  if (projectStore.techNetLoading || projectStore.techNetError) return false;
+  const data = currentTechData.value;
+  return !data || data.length === 0;
 });
 
 /**


### PR DESCRIPTION
## Summary
- add computed flags so the Social and Technical Network modules show a consistent "No data available for this month" overlay when the selected month lacks data
- add empty-state handling and styling for the Actionable Recommendations table so users get the same feedback when no recommendations are available

## Testing
- npm run build