### PR TITLE
Load API base URL from environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://ossprey.ngrok.app

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 src/.DS_Store
 src/.DS_Store
 /venv/
-.env

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import ChatWidget from '@/components/ChatWidget.vue';
+import { getApiBaseUrl } from '@/utils/apiBase';
 
 const route = useRoute();
 const router = useRouter();
@@ -17,7 +18,7 @@ let warningTimeoutId = null;
 let inactivityTimeoutId = null;
 let warningIntervalId = null;
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '');
+const API_BASE = getApiBaseUrl();
 
 const updateAuthenticationState = () => {
   try {

--- a/src/layouts/components/NavbarActions.vue
+++ b/src/layouts/components/NavbarActions.vue
@@ -1,10 +1,11 @@
 <script setup>
 import NavbarThemeSwitcher from '@/layouts/components/NavbarThemeSwitcher.vue';
 import AllReposButton from '@/layouts/components/AllReposButton.vue';
+import { getApiBaseUrl } from '@/utils/apiBase';
 
 const user = ref(null);
 const router = useRouter();
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '');
+const API_BASE = getApiBaseUrl();
 
 const loadUserFromStorage = () => {
   try {

--- a/src/pages/account-settings.vue
+++ b/src/pages/account-settings.vue
@@ -1,8 +1,9 @@
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { recordView } from '@/utils/viewTracking'
+import { getApiBaseUrl } from '@/utils/apiBase'
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+const API_BASE = getApiBaseUrl()
 
 const user = ref(null)
 const editDialog = ref(false)

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { recordView } from '@/utils/viewTracking'
+import { getApiBaseUrl } from '@/utils/apiBase'
 
 const email = ref('')
 const password = ref('')
@@ -13,7 +14,7 @@ const successMessage = ref('')
 const router = useRouter()
 const route = useRoute()
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+const API_BASE = getApiBaseUrl()
 
 // ------------------ MOUNT ------------------
 onMounted(() => {

--- a/src/pages/profile.vue
+++ b/src/pages/profile.vue
@@ -1,8 +1,9 @@
 <script setup>
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { recordView } from '@/utils/viewTracking'
+import { getApiBaseUrl } from '@/utils/apiBase'
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+const API_BASE = getApiBaseUrl()
 
 const user = ref(null)
 const nameInput = ref('')

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { getApiBaseUrl } from '@/utils/apiBase'
 
 const fullName = ref('')
 const email = ref('')
@@ -36,7 +37,7 @@ const generateCaptcha = () => {
 // Initialize captcha on component setup
 generateCaptcha()
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+const API_BASE = getApiBaseUrl()
 
 const passwordLengthValid = computed(() => password.value.length >= 8)
 const passwordHasLower = computed(() => /[a-z]/.test(password.value))

--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -1,10 +1,11 @@
 // src/stores/projectStore.js
 import { defineStore } from 'pinia';
 import { ref, computed, watch } from 'vue';
+import { getApiBaseUrl } from '@/utils/apiBase';
 
 export const useProjectStore = defineStore('projectStore', () => {
   // -------------------- Configuration --------------------
-  const baseUrl = ref('https://ossprey.ngrok.app/');  
+  const baseUrl = ref(getApiBaseUrl());
 
   const ngrokFetch = async (url, options = {}) => {
     const headers = {

--- a/src/utils/apiBase.js
+++ b/src/utils/apiBase.js
@@ -1,0 +1,8 @@
+const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '')
+
+export const getApiBaseUrl = () => {
+  if (!apiBaseUrl)
+    console.warn('VITE_API_BASE_URL is not set. API requests may fail.');
+
+  return apiBaseUrl
+}

--- a/src/utils/viewTracking.js
+++ b/src/utils/viewTracking.js
@@ -1,4 +1,6 @@
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '')
+import { getApiBaseUrl } from '@/utils/apiBase'
+
+const API_BASE = getApiBaseUrl()
 
 export const VIEW_RECORDED_EVENT = 'ossprey-view-recorded'
 

--- a/src/views/dashboard/ProjectSelector.vue
+++ b/src/views/dashboard/ProjectSelector.vue
@@ -145,6 +145,7 @@
 <script setup>
 import { onMounted, watch, computed, ref } from 'vue';
 import { useProjectStore } from '@/stores/projectStore';
+import { getApiBaseUrl } from '@/utils/apiBase';
 const projectStore = useProjectStore();
 
 // Data source: GitHub only (foundation option hidden for now)
@@ -175,7 +176,7 @@ const handleRepoSelection = (val) => {
     githubRepoLink.value = '';
 };
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL || 'https://ossprey.ngrok.app').replace(/\/$/, '');
+const API_BASE = getApiBaseUrl();
 const userRepos = ref([]);
 
 const fetchUserRepos = async () => {


### PR DESCRIPTION
## Summary
- add a shared helper to read the API base URL from VITE_API_BASE_URL
- update frontend pages, layout, and stores to pull API endpoints from the environment value instead of hardcoded URLs
- check in a .env template with the backend base URL

## Testing
- npm test