### PR TITLE
Add hover highlights to dashboard panels

### DIFF
--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -1,1 +1,26 @@
-// Write your overrides
+// Global interaction polish
+
+.hover-elevate {
+  transition: box-shadow 160ms ease, transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+  border: 1px solid transparent;
+}
+
+.hover-elevate:hover {
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.12);
+  border-color: color-mix(in srgb, var(--v-theme-primary) 30%, transparent);
+  background-color: color-mix(in srgb, var(--v-theme-surface) 88%, var(--v-theme-primary) 12%);
+  transform: translateY(-2px);
+}
+
+.hover-tab,
+.v-tab {
+  transition: background-color 140ms ease, box-shadow 140ms ease, color 140ms ease;
+  border-radius: 999px;
+}
+
+.hover-tab:hover,
+.v-tab:hover {
+  background-color: color-mix(in srgb, var(--v-theme-surface) 86%, var(--v-theme-primary) 14%);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+  color: var(--v-theme-primary);
+}

--- a/src/views/dashboard/Actionables.vue
+++ b/src/views/dashboard/Actionables.vue
@@ -1,6 +1,6 @@
 <!-- src/components/Actionables.vue -->
 <template>
-  <VCard class="text-center text-sm-start project-actionables-card">
+  <VCard class="text-center text-sm-start project-actionables-card hover-elevate">
     <VCardText>
       <div class="section-header">
         <h2>Actionable Recommendations</h2>

--- a/src/views/dashboard/CommitsPerCommitters.vue
+++ b/src/views/dashboard/CommitsPerCommitters.vue
@@ -1,7 +1,7 @@
 <!-- src/components/CommitsPerCommitter.vue -->
 
 <template>
-  <VCard class="mx-auto" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
+  <VCard class="mx-auto hover-elevate" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
     <VCardText>
       <VRow>
         <VCol cols="auto">

--- a/src/views/dashboard/Committers.vue
+++ b/src/views/dashboard/Committers.vue
@@ -1,7 +1,7 @@
 <!-- src/components/Committers.vue -->
 
 <template>
-  <VCard class="mx-auto" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
+  <VCard class="mx-auto hover-elevate" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
     <VCardText>
       <VRow>
         <VCol cols="auto">

--- a/src/views/dashboard/EmailsPerSender.vue
+++ b/src/views/dashboard/EmailsPerSender.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="mx-auto" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
+  <VCard class="mx-auto hover-elevate" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
     <VCardText>
       <VRow>
         <VCol cols="auto">

--- a/src/views/dashboard/GraduationForecast.vue
+++ b/src/views/dashboard/GraduationForecast.vue
@@ -1,6 +1,6 @@
 <!-- src/components/Graduationforecast.vue projectStore.selectedProject.start_date-->
 <template>
-  <VCard>
+  <VCard class="hover-elevate">
     <!-- Tabs Section -->
     <VCardText>
       <div class="section-header">

--- a/src/views/dashboard/NumberOfCommits.vue
+++ b/src/views/dashboard/NumberOfCommits.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="mx-auto" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
+  <VCard class="mx-auto hover-elevate" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
     <VCardText>
       <VRow>
         <VCol cols="auto">

--- a/src/views/dashboard/NumberOfEmails.vue
+++ b/src/views/dashboard/NumberOfEmails.vue
@@ -1,7 +1,7 @@
 <!-- src/components/NumberOfEmails.vue -->
 
 <template>
-  <VCard class="mx-auto" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
+  <VCard class="mx-auto hover-elevate" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1); height: 150px;">
     <VCardText>
       <VRow>
         <VCol cols="auto">

--- a/src/views/dashboard/ProjectDetails.vue
+++ b/src/views/dashboard/ProjectDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="text-center text-sm-start project-details-card">
+  <VCard class="text-center text-sm-start project-details-card hover-elevate">
     <VRow no-gutters class="h-100">
       <VCol cols="12" sm="12">
         <!-- Header -->

--- a/src/views/dashboard/ProjectSelector.vue
+++ b/src/views/dashboard/ProjectSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="text-center text-sm-start" style="height: 450px;">
+  <VCard class="text-center text-sm-start hover-elevate" style="height: 450px;">
     <VRow no-gutters>
       <VCol cols="12" sm="12">
         <!-- Header -->

--- a/src/views/dashboard/SeeAdvancedAnalytics.vue
+++ b/src/views/dashboard/SeeAdvancedAnalytics.vue
@@ -20,7 +20,7 @@ const toggleCollapse = () => {
 </script>
 
 <template>
-  <VCard class="statistics-card">
+  <VCard class="statistics-card hover-elevate">
     <!-- Card Header with Collapse Button -->
     <VCardText class="text-center d-flex align-center justify-center" style="height: 100%;">
       <VRow class="w-100 align-center justify-center">

--- a/src/views/dashboard/SendersBox.vue
+++ b/src/views/dashboard/SendersBox.vue
@@ -1,7 +1,7 @@
 <!-- src/components/Senders.vue -->
 
 <template>
-  <VCard class="mx-auto" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);height: 150px;">
+  <VCard class="mx-auto hover-elevate" style="box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);height: 150px;">
     <VCardText>
       <VRow>
         <VCol cols="auto">

--- a/src/views/dashboard/SocialNetwork.vue
+++ b/src/views/dashboard/SocialNetwork.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="text-center text-sm-start social-net-card">
+  <VCard class="text-center text-sm-start social-net-card hover-elevate">
     <!-- Header -->
     <VCardItem class="pb-3">
       <h2 class="section-header">Social Network</h2>

--- a/src/views/dashboard/SocialNetworkNode.vue
+++ b/src/views/dashboard/SocialNetworkNode.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="text-center text-sm-start" style="height: 120px;">
+  <VCard class="text-center text-sm-start hover-elevate" style="height: 120px;">
     <VRow no-gutters style="height: 100%;">
       <VCol cols="12" sm="12" order="2" order-sm="1">
         <!-- Header -->

--- a/src/views/dashboard/TechnicalNetwork.vue
+++ b/src/views/dashboard/TechnicalNetwork.vue
@@ -1,5 +1,5 @@
 <template>
-  <VCard class="text-center text-sm-start tech-net-card">
+  <VCard class="text-center text-sm-start tech-net-card hover-elevate">
     <!-- Header -->
     <VCardItem class="pb-3">
       <h2 class="section-header">Technical Network</h2>

--- a/src/views/dashboard/TechnicalNetworkNode.vue
+++ b/src/views/dashboard/TechnicalNetworkNode.vue
@@ -1,6 +1,6 @@
 <!-- src/components/TechnicalNetworkNode.vue -->
 <template>
-  <VCard class="text-center text-sm-start" style="height: 120px;">
+  <VCard class="text-center text-sm-start hover-elevate" style="height: 120px;">
     <VRow no-gutters style="height: 100%;">
       <VCol cols="12" sm="12" order="2" order-sm="1">
         <!-- Header -->

--- a/src/views/dashboard/Title.vue
+++ b/src/views/dashboard/Title.vue
@@ -4,7 +4,7 @@ import NavbarBranding from '@/layouts/components/NavbarBranding.vue';
 </script>
 
 <template>
-  <VCard class="statistics-card">
+  <VCard class="statistics-card hover-elevate">
     <VCardText class="header-container" style="height: 80px;">
       
       <!-- Logo + Title -->


### PR DESCRIPTION
## Summary
- add shared hover styles for dashboard cards and tabs to improve hover feedback
- apply interactive hover treatment to dashboard panels such as project selector, forecasts, networks, and metrics cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a804329c832aaa130d9505ba5031)