### PR TITLE
Add contextual tooltips to dashboard panels

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -11,6 +11,7 @@ declare module 'vue' {
     CardStatisticsVertical: typeof import('./src/@core/components/cards/CardStatisticsVertical.vue')['default']
     CardStatisticsWithImages: typeof import('./src/@core/components/cards/CardStatisticsWithImages.vue')['default']
     ChatWidget: typeof import('./src/components/ChatWidget.vue')['default']
+    DashboardPanelHeader: typeof import('./src/components/DashboardPanelHeader.vue')['default']
     MoreBtn: typeof import('./src/@core/components/MoreBtn.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/src/components/DashboardPanelHeader.vue
+++ b/src/components/DashboardPanelHeader.vue
@@ -1,25 +1,23 @@
 <template>
   <div class="section-header d-flex align-center">
     <h2 class="section-title mb-0">{{ title }}</h2>
-    <VTooltip
-      :text="tooltip"
-      location="top"
-      open-delay="150"
-      transition="fade-transition"
+    <VBtn
+      class="tooltip-btn"
+      variant="text"
+      size="small"
+      icon
+      :title="tooltip"
+      :aria-label="`${title} info`"
     >
-      <template #activator="{ props }">
-        <VBtn
-          v-bind="props"
-          variant="text"
-          size="small"
-          icon
-          class="tooltip-btn"
-          :aria-label="`${title} info`"
-        >
-          <VIcon icon="mdi-information-outline" />
-        </VBtn>
-      </template>
-    </VTooltip>
+      <VIcon icon="mdi-information-outline" />
+      <VTooltip
+        activator="parent"
+        :text="tooltip"
+        location="top"
+        open-delay="150"
+        transition="fade-transition"
+      />
+    </VBtn>
   </div>
 </template>
 
@@ -46,6 +44,7 @@ defineProps({
 .section-title {
   font-size: 1.25rem;
   font-weight: 600;
+  color: rgb(var(--v-theme-primary));
 }
 
 .tooltip-btn {

--- a/src/components/DashboardPanelHeader.vue
+++ b/src/components/DashboardPanelHeader.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="section-header d-flex align-center">
+    <h2 class="section-title mb-0">{{ title }}</h2>
+    <VTooltip
+      :text="tooltip"
+      location="top"
+      open-delay="150"
+      transition="fade-transition"
+    >
+      <template #activator="{ props }">
+        <VBtn
+          v-bind="props"
+          variant="text"
+          size="small"
+          icon
+          class="tooltip-btn"
+          :aria-label="`${title} info`"
+        >
+          <VIcon icon="mdi-information-outline" />
+        </VBtn>
+      </template>
+    </VTooltip>
+  </div>
+</template>
+
+<script setup>
+import { VBtn, VIcon, VTooltip } from 'vuetify/components';
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  tooltip: {
+    type: String,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.section-header {
+  gap: 8px;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.tooltip-btn {
+  color: rgb(var(--v-theme-primary));
+  min-width: 0;
+}
+</style>

--- a/src/components/DashboardPanelHeader.vue
+++ b/src/components/DashboardPanelHeader.vue
@@ -1,28 +1,22 @@
 <template>
   <div class="section-header d-flex align-center">
-    <h2 class="section-title mb-0">{{ title }}</h2>
-    <VBtn
-      class="tooltip-btn"
-      variant="text"
-      size="small"
-      icon
-      :title="tooltip"
-      :aria-label="`${title} info`"
+    <VTooltip
+      :text="tooltip"
+      location="top"
+      open-delay="150"
+      transition="fade-transition"
     >
-      <VIcon icon="mdi-information-outline" />
-      <VTooltip
-        activator="parent"
-        :text="tooltip"
-        location="top"
-        open-delay="150"
-        transition="fade-transition"
-      />
-    </VBtn>
+      <template #activator="{ props }">
+        <h2 class="section-title mb-0" v-bind="props" :title="tooltip">
+          {{ title }}
+        </h2>
+      </template>
+    </VTooltip>
   </div>
 </template>
 
 <script setup>
-import { VBtn, VIcon, VTooltip } from 'vuetify/components';
+import { VTooltip } from 'vuetify/components';
 
 defineProps({
   title: {
@@ -45,10 +39,5 @@ defineProps({
   font-size: 1.25rem;
   font-weight: 600;
   color: rgb(var(--v-theme-primary));
-}
-
-.tooltip-btn {
-  color: rgb(var(--v-theme-primary));
-  min-width: 0;
 }
 </style>

--- a/src/views/dashboard/Actionables.vue
+++ b/src/views/dashboard/Actionables.vue
@@ -2,9 +2,10 @@
 <template>
   <VCard class="text-center text-sm-start project-actionables-card hover-elevate">
     <VCardText>
-      <div class="section-header">
-        <h2>Actionable Recommendations</h2>
-      </div>
+      <DashboardPanelHeader
+        title="Researched Actionables (ReACTs)"
+        tooltip="Presents evidence-based interventions recommended when socio-technical metrics fall below historical baselines. Drawn from 186 peer-reviewed SE studies and mapped to project-specific needs."
+      />
     </VCardText>
 
     <VCardText class="d-flex align-center gap-3">
@@ -67,6 +68,7 @@
 
 <script setup>
 import { ref, computed } from 'vue';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useTheme } from 'vuetify';
 import { useProjectStore } from '@/stores/projectStore';
 import statsVerticalWallet from '@images/cards/wallet-primary.png';

--- a/src/views/dashboard/GraduationForecast.vue
+++ b/src/views/dashboard/GraduationForecast.vue
@@ -3,9 +3,10 @@
   <VCard class="hover-elevate">
     <!-- Tabs Section -->
     <VCardText>
-      <div class="section-header">
-        <h2>Probability of Sustainability</h2>
-      </div>
+      <DashboardPanelHeader
+        title="Probability of Sustainability"
+        tooltip="Shows OSSPREY’s transformer-based month-by-month sustainability predictions for the selected project. Includes historical values and three forward-looking forecast scenarios—positive, neutral, and negative—based on socio-technical dynamics."
+      />
     </VCardText>
 
     <!-- Tab Information Section -->
@@ -82,6 +83,7 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 import VueApexCharts from 'vue3-apexcharts';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { VDataTable, VAvatar, VCard, VCardText, VCardTitle, VRow, VCol, VTabs, VTab } from 'vuetify/components';
 import { useTheme } from 'vuetify';
 import { useProjectStore } from '@/stores/projectStore';

--- a/src/views/dashboard/ProjectDetails.vue
+++ b/src/views/dashboard/ProjectDetails.vue
@@ -4,7 +4,10 @@
       <VCol cols="12" sm="12">
         <!-- Header -->
         <VCardItem class="pb-3">
-          <h2 class="section-header">Project Details</h2>
+          <DashboardPanelHeader
+            title="Project Details"
+            tooltip="Displays project metadata such as name, sponsoring organization, GitHub URL, and popularity metrics (stars, forks, watchers). Provides contextual grounding for interpreting the project’s sustainability and activity patterns."
+          />
         </VCardItem>
 
         <VCardText class="h-100">
@@ -190,6 +193,7 @@
 
 <script setup>
 import { computed } from 'vue';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useProjectStore } from '@/stores/projectStore';
 
 const projectStore = useProjectStore();

--- a/src/views/dashboard/ProjectSelector.vue
+++ b/src/views/dashboard/ProjectSelector.vue
@@ -4,7 +4,10 @@
       <VCol cols="12" sm="12">
         <!-- Header -->
         <VCardItem class="pb-3">
-          <h2 class="section-header">Project Selector</h2>
+          <DashboardPanelHeader
+            title="Project Selector"
+            tooltip="Select any public GitHub repository to load its socio-technical activity, sustainability forecasts, and evidence-based interventions. All dashboard components update automatically based on the chosen repository and month."
+          />
         </VCardItem>
 
         <!-- Data Source Buttons -->
@@ -144,6 +147,7 @@
 
 <script setup>
 import { onMounted, watch, computed, ref } from 'vue';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useProjectStore } from '@/stores/projectStore';
 import { getApiBaseUrl } from '@/utils/apiBase';
 const projectStore = useProjectStore();

--- a/src/views/dashboard/SocialNetwork.vue
+++ b/src/views/dashboard/SocialNetwork.vue
@@ -2,7 +2,10 @@
   <VCard class="text-center text-sm-start social-net-card hover-elevate">
     <!-- Header -->
     <VCardItem class="pb-3">
-      <h2 class="section-header">Social Network</h2>
+      <DashboardPanelHeader
+        title="Social Network"
+        tooltip="Visualizes communication patterns among contributors using a directed socio-technical graph. Edge directions represent reply flows in issues or discussions, helping identify collaboration bottlenecks and central communicators."
+      />
     </VCardItem>
     <VCardText class="sankey-wrapper">
       <!-- Sankey Diagram Container -->
@@ -28,6 +31,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import * as d3 from 'd3';
 import { sankey, sankeyCenter, sankeyLinkHorizontal } from 'd3-sankey';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useProjectStore } from '@/stores/projectStore';
 import { VCard, VCardTitle, VCardText, VProgressCircular, VCardItem } from 'vuetify/components';
 

--- a/src/views/dashboard/SocialNetworkNode.vue
+++ b/src/views/dashboard/SocialNetworkNode.vue
@@ -4,7 +4,10 @@
       <VCol cols="12" sm="12" order="2" order-sm="1">
         <!-- Header -->
         <VCardItem class="pb-3">
-          <h2 class="section-header">Email Links</h2>
+          <DashboardPanelHeader
+            title="Email Links"
+            tooltip="Summarizes communication activity for the selected developer: number of messages, senders involved, and interaction frequency. Useful for understanding individual participation trends over time."
+          />
         </VCardItem>
 
         <VCardText>
@@ -64,6 +67,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useProjectStore } from '@/stores/projectStore';
 import { VCard, VCardText, VCol, VRow, VBtn, VDialog, VDataTable, VSpacer, VCardTitle, VCardItem, VCardActions } from 'vuetify/components';
 

--- a/src/views/dashboard/TechnicalNetwork.vue
+++ b/src/views/dashboard/TechnicalNetwork.vue
@@ -2,7 +2,10 @@
   <VCard class="text-center text-sm-start tech-net-card hover-elevate">
     <!-- Header -->
     <VCardItem class="pb-3">
-      <h2 class="section-header">Technical Network</h2>
+      <DashboardPanelHeader
+        title="Technical Network"
+        tooltip="Shows a bipartite developer-to-file-type network illustrating contribution patterns across the codebase. Helps identify code ownership, workload imbalance, and specialization patterns within the project."
+      />
     </VCardItem>
     <VCardText class="sankey-wrapper">
       <!-- Sankey Diagram Container -->
@@ -28,6 +31,7 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import * as d3 from 'd3';
 import { sankey, sankeyCenter, sankeyLinkHorizontal } from 'd3-sankey';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useProjectStore } from '@/stores/projectStore';
 import { VCard, VCardTitle, VCardText, VProgressCircular, VCardItem } from 'vuetify/components';
 

--- a/src/views/dashboard/TechnicalNetworkNode.vue
+++ b/src/views/dashboard/TechnicalNetworkNode.vue
@@ -5,7 +5,10 @@
       <VCol cols="12" sm="12" order="2" order-sm="1">
         <!-- Header -->
         <VCardItem class="pb-3">
-          <h2 class="section-header">Commit Links</h2>
+          <DashboardPanelHeader
+            title="Commit Links"
+            tooltip="Shows commit-level activity for the selected developer, including number of commits and affected file types. Supports analysis of workload, ownership, and contribution intensity."
+          />
         </VCardItem>
 
         <VCardText> 
@@ -65,6 +68,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue';
+import DashboardPanelHeader from '@/components/DashboardPanelHeader.vue';
 import { useProjectStore } from '@/stores/projectStore';
 import { VCard, VCardText, VCol, VRow, VBtn, VDialog, VDataTable, VSpacer, VCardTitle, VCardItem, VCardActions } from 'vuetify/components';
 


### PR DESCRIPTION
## Summary
- add a reusable dashboard header component with tooltip styling and accessibility
- apply research-grounded tooltip descriptions to all dashboard panel headers, including selector, sustainability forecasts, details, actionables, and social/technical link views

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b020ccb8832a9ae1ec49d6f923f1)