### PR TITLE
Handle month-keyed ReACT actionables

### DIFF
--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -643,17 +643,30 @@ export const useProjectStore = defineStore('projectStore', () => {
         return [];
       };
 
-      const normalizedActionables = (Array.isArray(reactJson) ? reactJson : [])
-        .map(entry => ({
-          title: entry.title,
-          importance: entry.importance || entry.Importance || 0,
-          refs: normalizeRefs(entry.refs)
-        }));
+      const normalizeEntry = (entry) => ({
+        title: entry.title,
+        importance: entry.importance || entry.Importance || 0,
+        refs: normalizeRefs(entry.refs)
+      });
 
-      // Select any 10 random actionables without filtering
-      reactData.value = normalizedActionables
-        .sort(() => Math.random() - 0.5)
-        .slice(0, 10);
+      const normalizeReactData = (reactPayload) => {
+        if (Array.isArray(reactPayload)) {
+          return reactPayload.map(normalizeEntry);
+        }
+
+        if (reactPayload && typeof reactPayload === 'object') {
+          return Object.entries(reactPayload).reduce((acc, [month, list]) => {
+            if (Array.isArray(list)) {
+              acc[month] = list.map(normalizeEntry);
+            }
+            return acc;
+          }, {});
+        }
+
+        return [];
+      };
+
+      reactData.value = normalizeReactData(reactJson);
 
       /*
        * Previous actionable filtering logic (kept for reference):

--- a/src/views/dashboard/Actionables.vue
+++ b/src/views/dashboard/Actionables.vue
@@ -96,15 +96,29 @@ const getBulletColor = (importance) => {
   else return 'green';                 // Low
 };
 
-// ------------------ Simplified: show 10 random actionables ------------------
+// ------------------ Show up to 10 actionables for the selected month ------------------
 const sortedActionables = computed(() => {
-  const actionables = Array.isArray(projectStore.reactData)
-    ? projectStore.reactData
-    : [];
+  const reactData = projectStore.reactData;
+  const monthKey = projectStore.selectedMonth !== null && projectStore.selectedMonth !== undefined
+    ? String(projectStore.selectedMonth)
+    : null;
 
-  return actionables.slice(0, 10);
+  let actionables = [];
+
+  if (Array.isArray(reactData)) {
+    actionables = reactData;
+  } else if (reactData && typeof reactData === 'object') {
+    if (monthKey && Array.isArray(reactData[monthKey])) {
+      actionables = reactData[monthKey];
+    } else {
+      const firstMonthEntries = Object.values(reactData).find(entry => Array.isArray(entry));
+      if (firstMonthEntries) actionables = firstMonthEntries;
+    }
+  }
+
+  return Array.isArray(actionables) ? actionables.slice(0, 10) : [];
 });
-// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 
 const hasActionables = computed(() => Array.isArray(sortedActionables.value) && sortedActionables.value.length > 0);
 


### PR DESCRIPTION
## Summary
- normalize ReACT payloads from updated_react_set.json so they support both array- and month-keyed formats
- render up to 10 actionables for the selected month in the dashboard panel instead of ignoring month-scoped data

## Testing
- npm run build -- --logLevel error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693959f154c8832ab79839e5450a6c2d)