### PR TITLE
Normalize ReACT data for backend format

### DIFF
--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -16,6 +16,54 @@ export const useProjectStore = defineStore('projectStore', () => {
     return fetch(url, { ...options, headers });
   };
 
+  // -------------------- Helpers --------------------
+  const normalizeRefs = (refs) => {
+    if (Array.isArray(refs)) {
+      return refs.map(ref => {
+        const cleanedRef = {};
+        if (ref.link) cleanedRef.link = ref.link;
+        if (ref.text && !ref.link) cleanedRef.text = ref.text;
+        return cleanedRef;
+      });
+    }
+
+    if (refs && typeof refs === 'object') {
+      const links = Array.isArray(refs.link) ? refs.link : [];
+
+      if (typeof refs.link === 'string') {
+        const matches = refs.link.match(/https?:\/\/[^',\s]+/g);
+        if (matches) links.push(...matches);
+      }
+
+      return links.map(link => ({ link }));
+    }
+
+    return [];
+  };
+
+  const normalizeReactEntry = (entry) => ({
+    title: entry.title,
+    importance: entry.importance || entry.Importance || 0,
+    refs: normalizeRefs(entry.refs)
+  });
+
+  const normalizeReactPayload = (reactPayload) => {
+    if (Array.isArray(reactPayload)) {
+      return reactPayload.map(normalizeReactEntry);
+    }
+
+    if (reactPayload && typeof reactPayload === 'object') {
+      return Object.entries(reactPayload).reduce((acc, [month, list]) => {
+        if (Array.isArray(list)) {
+          acc[month] = list.map(normalizeReactEntry);
+        }
+        return acc;
+      }, {});
+    }
+
+    return [];
+  };
+
 
   // Graduation Forecast State
   const gradForecastData = ref([]);
@@ -83,9 +131,7 @@ export const useProjectStore = defineStore('projectStore', () => {
 
       // ReACT data handling
       if (data.react) {
-        reactData.value = Array.isArray(data.react)
-          ? data.react
-          : (typeof data.react === 'object' ? data.react : []);
+        reactData.value = normalizeReactPayload(data.react);
         // console.log('ReACT Data:', reactData.value);
       } else {
         reactData.value = [];
@@ -619,54 +665,7 @@ export const useProjectStore = defineStore('projectStore', () => {
   
       const reactJson = await (await ngrokFetch('/updated_react_set.json')).json();
 
-      const normalizeRefs = (refs) => {
-        if (Array.isArray(refs)) {
-          return refs.map(ref => {
-            const cleanedRef = {};
-            if (ref.link) cleanedRef.link = ref.link;
-            if (ref.text && !ref.link) cleanedRef.text = ref.text;
-            return cleanedRef;
-          });
-        }
-
-        if (refs && typeof refs === 'object') {
-          const links = Array.isArray(refs.link) ? refs.link : [];
-
-          if (typeof refs.link === 'string') {
-            const matches = refs.link.match(/https?:\/\/[^',\s]+/g);
-            if (matches) links.push(...matches);
-          }
-
-          return links.map(link => ({ link }));
-        }
-
-        return [];
-      };
-
-      const normalizeEntry = (entry) => ({
-        title: entry.title,
-        importance: entry.importance || entry.Importance || 0,
-        refs: normalizeRefs(entry.refs)
-      });
-
-      const normalizeReactData = (reactPayload) => {
-        if (Array.isArray(reactPayload)) {
-          return reactPayload.map(normalizeEntry);
-        }
-
-        if (reactPayload && typeof reactPayload === 'object') {
-          return Object.entries(reactPayload).reduce((acc, [month, list]) => {
-            if (Array.isArray(list)) {
-              acc[month] = list.map(normalizeEntry);
-            }
-            return acc;
-          }, {});
-        }
-
-        return [];
-      };
-
-      reactData.value = normalizeReactData(reactJson);
+      reactData.value = normalizeReactPayload(reactJson);
 
       /*
        * Previous actionable filtering logic (kept for reference):


### PR DESCRIPTION
## Summary
- add shared helpers to normalize ReACT data and reference links
- reuse normalization when loading ReACT data from backend and forecasts so actionables render correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b981c968832ab4dd7e94d4c0bb5b)